### PR TITLE
Fix conflicting rlim64_t conflicting types

### DIFF
--- a/zpool.c
+++ b/zpool.c
@@ -2,8 +2,6 @@
  * using libzfs from go language, and make go code shorter and more readable.
  */
 
-typedef unsigned long int rlim64_t;
-
 #include <libzfs.h>
 #include <libzfs/sys/zfs_context.h>
 


### PR DESCRIPTION
Remove "typedef unsigned long int rlim64_t" as rlim64_t is already
defined in /usr/include/i386-linux-gnu/bits/resource.h on 32 bits.