### PR TITLE
Maps ZPOOL_PROP_AUTOTRIM to PoolPropAutotrim

### DIFF
--- a/common.go
+++ b/common.go
@@ -180,6 +180,7 @@ const (
 	PoolPropMultiHost
 	PoolPropCheckpoint
 	PoolPropLoadGuid
+	PoolPropAutotrim
 	PoolNumProps
 )
 


### PR DESCRIPTION
ZPOOL_PROP_AUTOTRIM is part of Trim support added in zfs 0.8
(https://github.com/zfsonlinux/zfs/commit/1b939560be5c51deecf875af9dada9d094633bf7).
Add it and prevents panic when pool is reloading its properties.
Fixes #19