### PR TITLE
Force refreshing property on C side when ReloadProperties()

### DIFF
--- a/zfs.go
+++ b/zfs.go
@@ -319,6 +319,7 @@ func (d *Dataset) ReloadProperties() (err error) {
 	d.Properties = make(map[Prop]Property)
 	Global.Mtx.Lock()
 	defer Global.Mtx.Unlock()
+	C.zfs_refresh_properties(d.list.zh)
 	for prop := DatasetPropType; prop < DatasetNumProps; prop++ {
 		plist := C.read_dataset_property(d.list, C.int(prop))
 		if plist == nil {


### PR DESCRIPTION
The properties weren't reloaded inonthe C dataset_list object when calling ReloadProperties.
Basically, the call only reset the Properties cache right now, and reload the same properties from the C dataset_list object.
Ensure we refresh the C side now.