### PR TITLE
Avoiding the nice bytes representation

### DIFF
--- a/zpool.c
+++ b/zpool.c
@@ -193,7 +193,7 @@ property_list_ptr read_zpool_property(zpool_list_ptr pool, int prop) {
 	property_list_ptr list = new_property_list();
 
 	r = zpool_get_prop(pool->zph, prop,
-		list->value, INT_MAX_VALUE, &source, B_FALSE);
+		list->value, INT_MAX_VALUE, &source, B_TRUE);
 	if (r == 0) {
 		// strcpy(list->name, zpool_prop_to_name(prop));
 		zprop_source_tostr(list->source, source);


### PR DESCRIPTION
Fixes #25

As can be noticed [here](https://github.com/zfsonlinux/zfs/blob/94a570e39c35522ad3bedf6f7873ca18e6422e91/lib/libzfs/libzfs_pool.c#L343-L348), `go-libzfs` was returning the _nicenum_ value representation.

Forcing to `B_TRUE` fixes the issue but this will be breaking: it need to be clearly documented in the release document.