### PR TITLE
Fix for dataset showing the wrong type (parent)

### DIFF
--- a/zfs.go
+++ b/zfs.go
@@ -229,9 +229,7 @@ func (d *Dataset) Destroy(Defer bool) (err error) {
 
 // IsSnapshot - retrun true if datset is snapshot
 func (d *Dataset) IsSnapshot() (ok bool) {
-	path := d.Properties[DatasetPropName].Value
-	ok = (d.Type == DatasetTypeSnapshot || strings.Contains(path, "@"))
-	return
+	return d.Type == DatasetTypeSnapshot
 }
 
 // DestroyRecursive recursively destroy children of dataset and dataset.

--- a/zfs.go
+++ b/zfs.go
@@ -59,7 +59,7 @@ func (d *Dataset) openChildren() (err error) {
 	list := C.dataset_list_children(d.list)
 	for list != nil {
 		dataset := Dataset{list: list}
-		dataset.Type = DatasetType(C.dataset_type(d.list))
+		dataset.Type = DatasetType(C.dataset_type(list))
 		dataset.Properties = make(map[Prop]Property)
 		err = dataset.ReloadProperties()
 		if err != nil {


### PR DESCRIPTION
Volume and snapshots datasets were showing type 1 (filesystem) which was the parent one.
Simplify thus the IsSnapshot() function.