### PR TITLE
Fix dataset close call

### DIFF
--- a/sendrecv.go
+++ b/sendrecv.go
@@ -110,7 +110,7 @@ func to_recvflags_t(flags *RecvFlags) (cflags *C.recvflags_t) {
 func (d *Dataset) send(FromName string, outf *os.File, flags *SendFlags) (err error) {
 	var cfromname, ctoname *C.char
 	var dpath string
-	var pd Dataset
+	var pd *Dataset
 
 	if d.Type != DatasetTypeSnapshot || (len(FromName) > 0 && strings.Contains(FromName, "#")) {
 		err = fmt.Errorf(
@@ -157,7 +157,7 @@ func (d *Dataset) SendResume(outf *os.File, flags *SendFlags, receiveResumeToken
 	}
 
 	var dpath string
-	var pd Dataset
+	var pd *Dataset
 
 	cflags := to_sendflags_t(flags)
 	defer C.free(unsafe.Pointer(cflags))

--- a/sort.go
+++ b/sort.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 )
 
-type clonesCreateDesc []Dataset
+type clonesCreateDesc []*Dataset
 
 func (list clonesCreateDesc) Less(i, j int) bool {
 	_, oki := list[i].Properties[DatasetNumProps+1000]


### PR DESCRIPTION
The closing of the children after the call to dataset_list_close causes
a detected double-free in the library. This code was removed.

I checked that the program was not leaking memory, but you may want to as well. You may find this program useful:

https://gist.github.com/erikh/fcf81b32fdb76bfe920a172b4a2c43b9

```go
package main

import (
	"fmt"
	"runtime"

	zfs "github.com/bicomsystems/go-libzfs"
)

func listChildren(datasets []zfs.Dataset, start []string) ([]string, error) {
	if start == nil {
		start = []string{}
	}

	for _, ds := range datasets {
		path, err := ds.Path()
		if err != nil {
			return nil, err
		}

		start = append(start, path)

		start, err = listChildren(ds.Children, start)
		if err != nil {
			return nil, err
		}

		ds.Close()
	}

	return start, nil
}

func main() {
	for i := 0; i < 1000000; i++ {
		ms := runtime.MemStats{}
		runtime.ReadMemStats(&ms)
		fmt.Printf("%v\n", ms.Alloc)
		runtime.GC()

		datasets, err := zfs.DatasetOpenAll()
		if err != nil {
			panic(err)
		}

		listChildren(datasets, nil)
	}
}
```