### PR TITLE
Fix compilation error for zfs-2.0.0-rc1

### DIFF
--- a/common.go
+++ b/common.go
@@ -10,7 +10,7 @@ package zfs
 
 /*
 #cgo CFLAGS: -I /usr/include/libzfs -I /usr/include/libspl -DHAVE_IOCTL_IN_SYS_IOCTL_H -D_GNU_SOURCE
-#cgo LDFLAGS: -lzfs -lzpool -lnvpair
+#cgo LDFLAGS: -lzfs -lzpool -lnvpair -lzfs_core
 
 #include <stdlib.h>
 #include <libzfs.h>

--- a/sendrecv.go
+++ b/sendrecv.go
@@ -21,11 +21,10 @@ import (
 
 // SendFlags send flags
 type SendFlags struct {
-	Verbose    bool // -v
+	Verbosity  int  // -v
 	Replicate  bool // -R
 	DoAll      bool // -I
 	FromOrigin bool // -o
-	Dedup      bool // -D
 	Props      bool // -p
 	DryRun     bool // -n
 	Parsable   bool // -P
@@ -75,11 +74,10 @@ func to_boolean_t(a bool) C.boolean_t {
 
 func to_sendflags_t(flags *SendFlags) (cflags *C.sendflags_t) {
 	cflags = C.alloc_sendflags()
-	cflags.verbose = to_boolean_t(flags.Verbose)
+	cflags.verbosity = C.int(flags.Verbosity)
 	cflags.replicate = to_boolean_t(flags.Replicate)
 	cflags.doall = to_boolean_t(flags.DoAll)
 	cflags.fromorigin = to_boolean_t(flags.FromOrigin)
-	cflags.dedup = to_boolean_t(flags.Dedup)
 	cflags.props = to_boolean_t(flags.Props)
 	cflags.dryrun = to_boolean_t(flags.DryRun)
 	cflags.parsable = to_boolean_t(flags.Parsable)
@@ -234,7 +232,7 @@ func (d *Dataset) SendSize(FromName string, flags SendFlags) (size int64, err er
 		close(errch)
 	}()
 	flags.DryRun = true
-	flags.Verbose = true
+	flags.Verbosity = 1
 	flags.Progress = true
 	flags.Parsable = true
 	if r, w, err = os.Pipe(); err != nil {


### PR DESCRIPTION
Fix a few compilation errors for zfs-2.0.0-rc1:

* libzutil is included in libzfs_core
* dedup flag was removed from sendflags_t
in "Remove deduplicated send/receive code" (196bee4)
* verbose flag was changed to verbosity of type int
in "Implement Redacted Send/Receive" (30af21b)