### PR TITLE
New pool property from libzfs 2.1

### DIFF
--- a/common.go
+++ b/common.go
@@ -181,6 +181,7 @@ const (
 	PoolPropCheckpoint
 	PoolPropLoadGuid
 	PoolPropAutotrim
+	PoolPropCompatibility
 	PoolNumProps
 )
 


### PR DESCRIPTION
This property was added in zfs 1.1.

This fixes a runtime crash due to number of properties on ZFS side being superior on the one in go-libzfs side.