### PR TITLE
Start porting 2.2.x compat

### DIFF
--- a/sendrecv.go
+++ b/sendrecv.go
@@ -21,11 +21,10 @@ import (
 
 // SendFlags send flags
 type SendFlags struct {
-	Verbose    bool // -v
+	Verbosity    uint64 // -v
 	Replicate  bool // -R
 	DoAll      bool // -I
 	FromOrigin bool // -o
-	Dedup      bool // -D
 	Props      bool // -p
 	DryRun     bool // -n
 	Parsable   bool // -P
@@ -75,11 +74,10 @@ func to_boolean_t(a bool) C.boolean_t {
 
 func to_sendflags_t(flags *SendFlags) (cflags *C.sendflags_t) {
 	cflags = C.alloc_sendflags()
-	cflags.verbose = to_boolean_t(flags.Verbose)
+	cflags.verbosity = C.int(flags.Verbosity)
 	cflags.replicate = to_boolean_t(flags.Replicate)
 	cflags.doall = to_boolean_t(flags.DoAll)
 	cflags.fromorigin = to_boolean_t(flags.FromOrigin)
-	cflags.dedup = to_boolean_t(flags.Dedup)
 	cflags.props = to_boolean_t(flags.Props)
 	cflags.dryrun = to_boolean_t(flags.DryRun)
 	cflags.parsable = to_boolean_t(flags.Parsable)
@@ -234,7 +232,7 @@ func (d *Dataset) SendSize(FromName string, flags SendFlags) (size int64, err er
 		close(errch)
 	}()
 	flags.DryRun = true
-	flags.Verbose = true
+	flags.Verbosity = 1
 	flags.Progress = true
 	flags.Parsable = true
 	if r, w, err = os.Pipe(); err != nil {

--- a/zfs.c
+++ b/zfs.c
@@ -132,8 +132,9 @@ int dataset_promote(dataset_list_ptr dataset) {
 	return zfs_promote(dataset->zh);
 }
 
-int dataset_rename(dataset_list_ptr dataset, const char* new_name, boolean_t recur, boolean_t force_unm) {
-	return zfs_rename(dataset->zh, new_name, recur, force_unm);
+int dataset_rename(dataset_list_ptr dataset, const char* new_name, boolean_t recur, boolean_t no_unm, boolean_t force_unm) {
+	renameflags_t flags = {recur, no_unm, force_unm};
+	return zfs_rename(dataset->zh, new_name, flags);
 }
 
 const char *dataset_is_mounted(dataset_list_ptr dataset){
@@ -191,8 +192,8 @@ property_list_t *read_user_property(dataset_list_t *dataset, const char* prop) {
 	nvlist_t *user_props = zfs_get_user_props(dataset->zh);
 	nvlist_t *propval;
 	zprop_source_t sourcetype;
-	char *strval;
-	char *sourceval;
+	const char *strval;
+	const char *sourceval;
 	// char source[ZFS_MAX_DATASET_NAME_LEN];
 	property_list_ptr list = new_property_list();
 	

--- a/zfs.go
+++ b/zfs.go
@@ -510,7 +510,7 @@ func (d *Dataset) Promote() (err error) {
 
 // Rename dataset
 func (d *Dataset) Rename(newName string, recur,
-	forceUnmount bool) (err error) {
+	noUnmount, forceUnmount bool) (err error) {
 	if d.list == nil {
 		err = errors.New(msgDatasetIsNil)
 		return
@@ -518,7 +518,7 @@ func (d *Dataset) Rename(newName string, recur,
 	csNewName := C.CString(newName)
 	defer C.free(unsafe.Pointer(csNewName))
 	if errc := C.dataset_rename(d.list, csNewName,
-		booleanT(recur), booleanT(forceUnmount)); errc != 0 {
+		booleanT(recur), booleanT(noUnmount), booleanT(forceUnmount)); errc != 0 {
 		err = LastError()
 		return
 	}
@@ -729,7 +729,7 @@ func (d *Dataset) DestroyPromote() (err error) {
 				// snapshot with the same name already exist
 				volname := path.Base(spath[:strings.Index(spath, "@")])
 				sname = sname + "." + volname
-				if err = s.Rename(spath+"."+volname, false, true); err != nil {
+				if err = s.Rename(spath+"."+volname, false, false, true); err != nil {
 					return
 				}
 			}

--- a/zfs.h
+++ b/zfs.h
@@ -122,7 +122,7 @@ int dataset_clone(dataset_list_ptr dataset, const char *target, nvlist_ptr props
 int dataset_snapshot(const char *path, boolean_t recur, nvlist_ptr props);
 int dataset_rollback(dataset_list_ptr dataset, dataset_list_ptr snapshot, boolean_t force);
 int dataset_promote(dataset_list_ptr dataset);
-int dataset_rename(dataset_list_ptr dataset, const char* new_name, boolean_t recur, boolean_t force_unm);
+int dataset_rename(dataset_list_ptr dataset, const char* new_name, boolean_t recur, boolean_t no_unm, boolean_t force_unm);
 const char* dataset_is_mounted(dataset_list_ptr dataset);
 int dataset_mount(dataset_list_ptr dataset, const char *options, int flags);
 int dataset_unmount(dataset_list_ptr dataset, int flags);

--- a/zpool.c
+++ b/zpool.c
@@ -370,7 +370,7 @@ int refresh_stats(zpool_list_t *pool)
 }
 
 const char *get_vdev_type(nvlist_ptr nv) {
-	char *value = NULL;
+	const char *value = NULL;
 	int r = nvlist_lookup_string(nv, ZPOOL_CONFIG_TYPE, &value);
 	if(r != 0) {
 		return NULL;
@@ -441,7 +441,7 @@ vdev_children_ptr get_vdev_l2cache(nvlist_t *nv) {
 }
 
 const char *get_vdev_path(nvlist_ptr nv) {
-	char *path = NULL;
+	const char *path = NULL;
 	uint64_t notpresent = 0;
 	int r = nvlist_lookup_uint64(nv, ZPOOL_CONFIG_NOT_PRESENT, &notpresent);
 	if (r == 0 || notpresent != 0) {
@@ -473,7 +473,7 @@ uint64_t get_zpool_guid(nvlist_ptr nv) {
 }
 
 const char *get_zpool_name(nvlist_ptr nv) {
-	char *name = NULL;
+	const char *name = NULL;
 	if (0 != nvlist_lookup_string(nv, ZPOOL_CONFIG_POOL_NAME, &name)) {
 		return NULL;
 	}
@@ -481,7 +481,7 @@ const char *get_zpool_name(nvlist_ptr nv) {
 }
 
 const char *get_zpool_comment(nvlist_ptr nv) {
-	char *comment = NULL;
+	const char *comment = NULL;
 	if (0 != nvlist_lookup_string(nv, ZPOOL_CONFIG_COMMENT, &comment)) {
 		return NULL;
 	}
@@ -510,7 +510,12 @@ nvlist_ptr go_zpool_search_import(libzfs_handle_ptr zfsh, int paths, char **path
 	if (t == NULL)
 			return NULL;
 
-	pools = zpool_search_import(zfsh, &idata, &libzfs_config_ops);
+	libpc_handle_t lpch = {
+		.lpc_lib_handle = zfsh,
+		.lpc_ops = &libzfs_config_ops,
+		.lpc_printerr = B_TRUE
+	};
+	pools = zpool_search_import(&lpch, &idata);
 
 	tpool_wait(t);
 	tpool_destroy(t);


### PR DESCRIPTION
zfs-linux development branch (version set to 2.1.99, to become 2.2.x series) has a few chnages that prevent go-libzfs form compiling.

I have attempted to start porting it over, however it seems like many operations are incompatible. This no passes `go build` but fails `go test`. Will debug further.